### PR TITLE
SRCH-3528 update bundler & gems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,40 +2,49 @@
 #
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
-version: 2
+version: 2.1
+
+orbs:
+  ruby: circleci/ruby@2.0.0
+
 jobs:
-  build:
+  build_and_test:
+    parameters:
+      ruby_version:
+        type: string
     environment:
       CC_TEST_REPORTER_ID: 04c5e730214438ccb56fa2e218bc65bcc1ae4ea86efb5c1f58f7eb9cc065c82a
       COVERAGE: true
     docker:
-      - image: circleci/ruby:2.4.1-node-browsers
+      - image: cimg/ruby:<< parameters.ruby_version >>
 
     working_directory: ~/robots_tag_parser
 
     steps:
       - checkout
 
-      - run:
-          name: Install Dependencies
-          command: |
-            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      # Install gems with Bundler
+      - ruby/install-deps:
+          # Need to clear the gem cache? Set or bump the CACHE_VERSION in your
+          # CircleCi project: Project Settings > Environment Variables
+          key: gems-ruby-<< parameters.ruby_version >>-v{{ .Environment.CACHE_VERSION }}
 
       - run:
-          name: Install Code Climate Test Reporter
+          name: Prepare Code Climate Test Reporter
           command: |
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
             chmod +x ./cc-test-reporter
-
-      - run:
-          name: Run Tests
-          command: |
-            mkdir /tmp/test-results
             ./cc-test-reporter before-build
 
-            bundle exec rspec --format progress --format documentation --out /tmp/test-results/rspec.txt \
-              $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
-             ./cc-test-reporter after-build --exit-code $?
+      - ruby/rspec-test:
+          # Need to temporarily test with a particular seed? Use:
+          # order: rand:123
+          order: rand
+
+      - run:
+          name: Report Test Results
+          command: |
+            ./cc-test-reporter after-build
 
       # collect reports
       - store_test_results:
@@ -43,3 +52,15 @@ jobs:
       - store_artifacts:
           path: /tmp/test-results
           destination: test-results
+
+workflows:
+  build_and_test:
+    jobs:
+      - build_and_test:
+          name: "Ruby << matrix.ruby_version >>"
+          matrix:
+            parameters:
+              ruby_version:
+                - 2.7.6
+                - 3.0.4
+                - 3.1.2

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+- Brief summary of the changes included in this PR
+- Any additional information or context which may help the reviewer
+ 
+### Checklist
+Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
+ 
+#### Functionality Checks
+- [ ] You have merged the latest changes from the target branch (usually `main`) into your branch.
+ 
+- [ ] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.
+ 
+- [ ] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
+ 
+- [ ] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:  
+
+#### Process Checks
+ 
+- [ ] You have specified at least one "Reviewer".

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/
@@ -10,3 +9,6 @@
 
 # rspec failure tracking
 .rspec_status
+
+# Ignore the rubocop YAML file that is downloaded when running `rubocop` locally
+.rubocop*default-yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+inherit_from:
+  - https://raw.githubusercontent.com/GSA/searchgov_style/main/.default.yml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,111 @@
+PATH
+  remote: .
+  specs:
+    robots_tag_parser (0.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (7.0.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    ast (2.4.2)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.10)
+    debug (1.6.3)
+      irb (>= 1.3.6)
+      reline (>= 0.3.1)
+    diff-lcs (1.5.0)
+    docile (1.4.0)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
+    io-console (0.5.11)
+    irb (1.4.2)
+      reline (>= 0.3.0)
+    method_source (1.0.0)
+    minitest (5.16.3)
+    parallel (1.22.1)
+    parser (3.1.2.1)
+      ast (~> 2.4.1)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rack (3.0.0)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    regexp_parser (2.6.0)
+    reline (0.3.1)
+      io-console (~> 0.5)
+    rexml (3.2.5)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.0)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+    rspec_junit_formatter (0.5.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
+    rubocop (1.31.0)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.18.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.23.0)
+      parser (>= 3.1.1.0)
+    rubocop-performance (1.15.0)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    rubocop-rails (2.15.2)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.7.0, < 2.0)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
+    rubocop-rspec (2.12.1)
+      rubocop (~> 1.31)
+    ruby-progressbar (1.11.0)
+    searchgov_style (0.1.20)
+      rubocop (= 1.31.0)
+      rubocop-performance (~> 1.9)
+      rubocop-rails (~> 2.9)
+      rubocop-rake (~> 0.5)
+      rubocop-rspec (~> 2.5)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (>= 2.3)
+  debug
+  pry
+  rake
+  robots_tag_parser!
+  rspec (~> 3.0)
+  rspec_junit_formatter
+  searchgov_style
+  simplecov
+
+BUNDLED WITH
+   2.3.15

--- a/robots_tag_parser.gemspec
+++ b/robots_tag_parser.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "robots_tag_parser/version"
@@ -21,9 +20,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.15"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", ">= 2.3"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "pry", "~> 0.10.4"
-  spec.add_development_dependency "simplecov", "~> 0.12.0"
+  spec.add_development_dependency "rspec_junit_formatter" # used in CircleCI
+  spec.add_development_dependency "pry"
+  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "debug"
+  spec.add_development_dependency "searchgov_style"
 end


### PR DESCRIPTION
## Summary
This PR primarily bumps the version of several gems. However, as this repo hadn't been updated in quite a while, it was also missing certain repo-related updates, so it also includes the following changes:
```
- bump bundler & gem versions
- install searchgov_style & debug gems
- check in Gemfile.lock
- update CircleCI config
- relax versions for development dependencies
- add PR template
```

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

⚠️  Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:
This PR passes CircleCI: https://app.circleci.com/pipelines/github/MothOnMars/robots_tag_parser/15/workflows/43ae38c0-457b-4d62-a069-e15980ed0939
For some reason, the automated checks are not appearing in this repo. A [test PR](https://github.com/GSA/robots_tag_parser/pull/12) without these changes has the same issue, so I'll file a follow-up ticket to investigate. 

#### Process Checks

- [x] You have specified at least one "Reviewer".